### PR TITLE
Role upgrade (remove deprecated package and syntax, upgrade PHP default version)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Required packages (installed automatically) :
   - php7-fpm
   - php7.0-opcache
   - php-apcu
-  - php7.0-mcrypt
   - php7.0-gd
   - php7.0-curl
   - php-pear

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,4 +8,4 @@ php7_mbstring_http_input: "auto"
 php7_memory_limit: 128M
 php7_post_max_size: 40M
 php7_upload_max_filesize: 20M
-php7_version: 7.0
+php7_version: 7.2

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,3 +9,23 @@ php7_memory_limit: 128M
 php7_post_max_size: 40M
 php7_upload_max_filesize: 20M
 php7_version: 7.2
+php7_default_packages:
+  - php{{ php7_version }}-fpm
+  - composer
+  - php-apcu
+  - php-pear
+  - php{{ php7_version }}-bz2
+  - php{{ php7_version }}-cli
+  - php{{ php7_version }}-curl
+  - php{{ php7_version }}-gd
+  - php{{ php7_version }}-intl
+  - php{{ php7_version }}-mbstring
+  - php{{ php7_version }}-mysql
+  - php{{ php7_version }}-opcache
+  - php{{ php7_version }}-readline
+  - php{{ php7_version }}-xml
+  - php{{ php7_version }}-zip
+
+php7_all_packages:
+  - "{{ php7_default_packages }}"
+  - "{{ php7_module_debs }}"

--- a/tasks/php7-fpm.yml
+++ b/tasks/php7-fpm.yml
@@ -9,28 +9,11 @@
 
 - name: Installs php7-fpm
   apt:
-    pkg: "{{ item }}"
+    pkg: "{{ php7_all_packages }}"
     state: latest
     update_cache: yes
   notify:
     - Restart php7-fpm
-  with_items:
-    - php{{ php7_version }}-fpm
-    - composer
-    - php-apcu
-    - php-pear
-    - php{{ php7_version }}-bz2
-    - php{{ php7_version }}-cli
-    - php{{ php7_version }}-curl
-    - php{{ php7_version }}-gd
-    - php{{ php7_version }}-intl
-    - php{{ php7_version }}-mbstring
-    - php{{ php7_version }}-mysql
-    - php{{ php7_version }}-opcache
-    - php{{ php7_version }}-readline
-    - php{{ php7_version }}-xml
-    - php{{ php7_version }}-zip
-    - "[{{ php7_module_debs }}]"
 
 - name: Adds php.ini
   template:

--- a/tasks/php7-fpm.yml
+++ b/tasks/php7-fpm.yml
@@ -25,7 +25,6 @@
     - php{{ php7_version }}-gd
     - php{{ php7_version }}-intl
     - php{{ php7_version }}-mbstring
-    - php{{ php7_version }}-mcrypt
     - php{{ php7_version }}-mysql
     - php{{ php7_version }}-opcache
     - php{{ php7_version }}-readline

--- a/templates/php.ini.j2
+++ b/templates/php.ini.j2
@@ -1857,17 +1857,6 @@ soap.wsdl_cache_limit = 5
 ; Sets the maximum number of open links or -1 for unlimited.
 ldap.max_links = -1
 
-[mcrypt]
-; For more information about mcrypt settings see http://php.net/mcrypt-module-open
-
-; Directory where to load mcrypt algorithms
-; Default: Compiled in into libmcrypt (usually /usr/local/lib/libmcrypt)
-;mcrypt.algorithms_dir=
-
-; Directory where to load mcrypt modes
-; Default: Compiled in into libmcrypt (usually /usr/local/lib/libmcrypt)
-;mcrypt.modes_dir=
-
 [dba]
 ;dba.default_handler=
 


### PR DESCRIPTION
- remove mcrypt module (deprecated in PHP7.2)
- remove loop syntax for apt task (deprecated in Ansible)
- upgrade PHP default version (from 7.0 to 7.2)

resolve issue #1 